### PR TITLE
Use Global IDs for Shared Redis Sessions Across Multiple Apps

### DIFF
--- a/lib/pg_rls/middleware/set_reset_connection.rb
+++ b/lib/pg_rls/middleware/set_reset_connection.rb
@@ -80,7 +80,8 @@ module PgRls
         return if tenant_session.blank?
         return if tenant_session['_tenant'].blank?
 
-        tenant_session['_tenant'] if tenant_session.present?
+        GlobalID::Locator.locate(tenant_session['_tenant']) if tenant_session['_tenant'].present?
+
       rescue TypeError
         nil
       end

--- a/lib/pg_rls/multi_tenancy.rb
+++ b/lib/pg_rls/multi_tenancy.rb
@@ -17,11 +17,11 @@ module PgRls
     private
 
     def switch_tenant!
-      fetched_tenant = session[:_tenant] || current_tenant
+      fetched_tenant = GlobalID::Locator.locate(session[:_tenant]) || current_tenant
       return yield if PgRls::Tenant.fetch.present?
 
       Tenant.with_tenant!(fetched_tenant) do |tenant|
-        session[:_tenant] = tenant
+        session[:_tenant] = tenant.to_global_id.to_s
         yield(tenant)
       end
     rescue NoMethodError


### PR DESCRIPTION
## Use Global IDs for Shared Redis Sessions Across Multiple Apps

### Problem:
We have two separate Rails applications sharing the same Redis instance for session storage. For now, the tenants are stored as ActiveRecord objects directly in Redis using Ruby's Marshal serialization. This works well when accessing sessions within the same application. However, when trying to deserialize these objects in another application, we encounter errors like `NameError: uninitialized constant ActiveModel::LazyAttributeSet`. This is due to differences in the environment and the classes loaded in each application.

### Steps to Reproduce:
1. In App1, serialize and store an ActiveRecord object (e.g. in our case, it is a `Headquarter`) in Redis.
2. In App2, attempt to deserialize this object from Redis.

### Proposed Solution:

To resolve this, I propose using [Rails' Global ID (GID)](https://github.com/rails/globalid) system. Instead of serializing the entire ActiveRecord object, we serialize its Global ID. Global IDs are universally unique identifiers for any model in your Rails app, not just those backed by ActiveRecord. This change will ensure compatibility across different applications, as Global IDs are just strings that can be easily serialized and deserialized in any environment.

### Implementation:
- Modify the serialization process to use `to_global_id.to_s` on ActiveRecord objects before storing them in Redis.
- Upon retrieval, the Global ID can be resolved back to the original ActiveRecord object if needed.

### Example:
**In App1:**
```ruby
r.set(:test, Marshal.dump(Headquarter.last.to_global_id.to_s))
```

**In App2:**
```ruby
gid = Marshal.load(r.get(:test))
headquarter = GlobalID::Locator.locate(gid)
```

### Benefits:
- Eliminates the `NameError` and related deserialization issues when accessing shared Redis sessions across different applications.
- Enhances the flexibility and robustness of our session management strategy.
- Aligns with Rails' standard practices for handling identifiers across different systems.